### PR TITLE
Hathitrust check passes

### DIFF
--- a/app/models/hathitrust.rb
+++ b/app/models/hathitrust.rb
@@ -144,15 +144,18 @@ class Hathitrust
     task.update!(name: 'Checking HathiTrust: downloading HathiFile index...')
     puts task.name
 
-    base_url     = 'https://www.hathitrust.org'
-    response     = Net::HTTP.get_response(URI('https://www.hathitrust.org/hathifiles'))
-
+    uri          = URI.parse('https://www.hathitrust.org/hathifiles')
+    response     = Net::HTTP.get_response(uri)
     location     = response['location']
+    base_url     = 'https://www.hathitrust.org'
     res          = base_url + location 
 
-    new_response = Net::HTTP.get_response(URI(res))
-
-    page         = Nokogiri::HTML(new_response.body)
+    if response.code.start_with?("3")
+      new_response = Net::HTTP.get_response(URI(res))
+      page         = Nokogiri::HTML(new_response.body)
+    else
+      page         = Nokogiri::HTML(response.body)
+    end
 
     # Scrape the URI of the latest HathiFile out of the index
 

--- a/app/models/hathitrust.rb
+++ b/app/models/hathitrust.rb
@@ -14,12 +14,12 @@ class Hathitrust
         where('status IN (?)', [Task::Status::RUNNING]).count == 0
   end
 
-  # ##
-  # # Checks HathiTrust by downloading the latest HathiFile
-  # # (http://www.hathitrust.org/hathifiles).
-  # #
-  # # @param task [Task] Optional. If not provided, one will be created.
-  # #
+  ##
+  # Checks HathiTrust by downloading the latest HathiFile
+  # (http://www.hathitrust.org/hathifiles).
+  #
+  # @param task [Task] Optional. If not provided, one will be created.
+  #
   def check(task = nil)
     raise 'Another HathiTrust check is in progress.' unless self.class.check_authorized?
 
@@ -47,7 +47,7 @@ class Hathitrust
 
       num_lines = File.foreach(pathname).count
 
-  #     http://www.hathitrust.org/hathifiles_description
+      # http://www.hathitrust.org/hathifiles_description
       File.open(pathname).each_with_index do |line, index|
         parts = line.split("\t")
         if parts[5] == nuc_code
@@ -91,19 +91,19 @@ class Hathitrust
     end
   end
 
-  # ##
-  # # Invokes a rake task via an ECS task to check the service.
-  # #
-  # # @param task [Task]
-  # # @return [void]
-  # #
+  ##
+  # Invokes a rake task via an ECS task to check the service.
+  #
+  # @param task [Task]
+  # @return [void]
+  #
   def check_async(task)
     unless Rails.env.production? or Rails.env.demo?
       raise 'This feature only works in production. '\
           'Elsewhere, use a rake task instead.'
     end
 
-  #   # https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/ECS/Client.html#run_task-instance_method
+  # https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/ECS/Client.html#run_task-instance_method
     config = Configuration.instance
     ecs = Aws::ECS::Client.new
     args = {
@@ -129,6 +129,7 @@ class Hathitrust
     ecs.run_task(args)
   end
 
+  private
   
   ##
   # Downloads the latest HathiFile.
@@ -136,7 +137,6 @@ class Hathitrust
   # @return The path of the HathiFile
   #
       
-  private
 
   def get_hathifile(task)
     # As there is no single URI for the latest HathiFile, we have to scrape
@@ -177,7 +177,7 @@ class Hathitrust
     Dir.glob(File.join(TEMP_DIR, 'hathi_full_*.txt')).
       each { |f| File.delete(f) }
 
-  #   And progressively download the new one (because it's big)
+    # And progressively download the new one (because it's big)
     task.name = "Checking HathiTrust: downloading the latest HathiFile "\
     "(#{gz_filename})..."
     task.save!
@@ -200,16 +200,3 @@ class Hathitrust
     txt_pathname
   end
 end
-
-
-  #   uri      = URI.parse('https://www.hathitrust.org/hathifiles')
-  #   response = Net::HTTP.get_response(uri)
-    
-  #   if response.is_a?(Net::HTTPRedirection)
-  #     response = response['Location']
-  #     puts 'Redirected' 
-  #     # can remove the puts statement if needed
-  #     # I included it to see if the method works as expected
-  #   else
-  #     response 
-  #   end

--- a/app/models/hathitrust.rb
+++ b/app/models/hathitrust.rb
@@ -103,7 +103,7 @@ class Hathitrust
           'Elsewhere, use a rake task instead.'
     end
 
-  # https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/ECS/Client.html#run_task-instance_method
+    # https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/ECS/Client.html#run_task-instance_method
     config = Configuration.instance
     ecs = Aws::ECS::Client.new
     args = {
@@ -168,6 +168,7 @@ class Hathitrust
 
     # If we already have it, return its pathname instead of downloading it.
     return txt_pathname if File.exists?(txt_pathname)
+
     # Otherwise, delete any older HathiFiles that may exist, as they are now
     # out-of-date.
     # (This code is from when the application ran in a persistent VM; now
@@ -175,7 +176,7 @@ class Hathitrust
     # doesn't hurt.)
 
     Dir.glob(File.join(TEMP_DIR, 'hathi_full_*.txt')).
-      each { |f| File.delete(f) }
+        each { |f| File.delete(f) }
 
     # And progressively download the new one (because it's big)
     task.name = "Checking HathiTrust: downloading the latest HathiFile "\

--- a/app/models/hathitrust.rb
+++ b/app/models/hathitrust.rb
@@ -135,52 +135,26 @@ class Hathitrust
   #
   # @return The path of the HathiFile
   #
-  # TODO - Take into account if Net::HTTP needs to handle a redirect 
-
- 
-    # if response.code == "302"
-    #   new_location = response['Location']
-    #   uri = URI.parse(new_location)
-    #   response = Net::HTTP.get_response(uri)
-    #   page     = Nokogiri::HTML(response.body)
-    # end
       
-  # def check_redirect
-  #   uri      = URI.parse('https://www.hathitrust.org/hathifiles')
-  #   response = Net::HTTP.get_response(uri)
-    
-  #   if response.is_a?(Net::HTTPRedirection)
-  #     response = response['Location']
-  #     puts 'Redirected' 
-  #     # can remove the puts statement if needed
-  #     # I included it to see if the method works as expected
-  #   else
-  #     response 
-  #   end
-  # end
   private
-  
-  # TODO - Figure out how to extract the correct css element to retrieve the latest HathiFile
+
   def get_hathifile(task)
     # As there is no single URI for the latest HathiFile, we have to scrape
     # the HathiFile listing out of the index HTML page.
     task.update!(name: 'Checking HathiTrust: downloading HathiFile index...')
     puts task.name
 
-    uri      = URI.parse("https://www.hathitrust.org/member-libraries/resources-for-librarians/data-resources/hathifiles/")
-    response = Net::HTTP.get_response(uri)
-    page     = Nokogiri::HTML(response.body)
+    base_url     = 'https://www.hathitrust.org'
+    response     = Net::HTTP.get_response(URI('https://www.hathitrust.org/hathifiles'))
 
+    location     = response['location']
+    res          = base_url + location 
+
+    new_response = Net::HTTP.get_response(URI(res))
+
+    page         = Nokogiri::HTML(new_response.body)
 
     # Scrape the URI of the latest HathiFile out of the index
-
-
-    # returns <a> elements
-    # for each of the <a> elements extract the text for each element
-    # if the text starts with 'hathi_full_'
-    
-    # sort those 'hathi_full_' <a> elements by their text id, reverse the order, and 
-    # extract the first one (output should be something like: hathi_full_2020202.txt.gz)
 
     node = page.css('.btable-wrapper table.btable tbody tr td a')
                     .select{ |h| h.text.start_with?('hathi_full_') }
@@ -225,23 +199,17 @@ class Hathitrust
 
     txt_pathname
   end
-  
-
 end
 
-     
 
-      
-
-      ### ORIGINAL CODE ###
-
-      # node = page.css('div#content-area table.sticky-enabled a').
-      #     select{ |h| h.text.start_with?('hathi_full_') }.
-      #     sort{ |x,y| x.text <=> y.text }.reverse[0]
-      # uri          = node['href']
-      # gz_filename  = node.text
-      # txt_filename = gz_filename.chomp('.gz')
-      # gz_pathname  = File.join(TEMP_DIR, gz_filename)
-      # txt_pathname = File.join(TEMP_DIR, txt_filename)
-
-      ### ORIGINAL CODE ###
+  #   uri      = URI.parse('https://www.hathitrust.org/hathifiles')
+  #   response = Net::HTTP.get_response(uri)
+    
+  #   if response.is_a?(Net::HTTPRedirection)
+  #     response = response['Location']
+  #     puts 'Redirected' 
+  #     # can remove the puts statement if needed
+  #     # I included it to see if the method works as expected
+  #   else
+  #     response 
+  #   end

--- a/app/models/hathitrust.rb
+++ b/app/models/hathitrust.rb
@@ -245,35 +245,3 @@ end
       # txt_pathname = File.join(TEMP_DIR, txt_filename)
 
       ### ORIGINAL CODE ###
-
-# accessing the latest file in JS console in browswer: 
-
-# const elements = document.querySelector('.btable-wrapper table.btable tbody tr td a');
-# const matchingElements = [];
-# elements.forEach((element) => {
-#   const textContent = element.textContent;
-#   if (textContent.startsWith('hathi_full_')) {
-#     matchingElements.push(element);
-#   }
-# });
-
-# console.log(matchingElements);
-
-# [a, a, a]
-
-# matchingElements.sort((x, y) => {
-#   const textX = x.textContent;
-#   const textY = y.textContent;
-#   return textX.localeCompare(textY);
-# });
-
-# matchingElements.reverse();
-
-# matchingElements.forEach((element) => {
-#   const hrefVal = element.href;
-#   console.log(hrefVal);
-# });
-
-# hathi_full_1
-# hathi_full_2
-# hathi_full_3 


### PR DESCRIPTION
**Update: This now includes code to handle redirects (3xx) based on location header** 

This PR handles the hathitrust check failure. 

- Based on HTML structure changes on hathitrust site, the `get_hathifile(task)` method now extracts elements with a different css query: `'.btable-wrapper table.btable tbody tr td a'`
- This query was found using the JavaScript console in my browser
- ~~The `uri` has been changed to the temporary/redirect location for now `("https://www.hathitrust.org/member-libraries/resources-for-librarians/data-resources/hathifiles/")` just to be sure the new query allows the check to pass~~

<img width="847" alt="Screen Shot 2023-09-13 at 3 31 36 PM" src="https://github.com/medusa-project/book-tracker/assets/103534307/ca2612c6-359a-4781-89ef-9ef1b97fef72">



~~**Note: **I will update this PR with a conditional to handle the redirect more gracefully, especially since the uri may change again in the future****~~