### PR TITLE
Automate Hathitrust Check

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -37,22 +37,6 @@ class TasksController < ApplicationController
   end
 
   ##
-  # Responds to POST /check-hathitrust
-  #
-  def check_hathitrust
-    task = Task.create!(name: 'Preparing to check HathiTrust',
-                        service: Service::HATHITRUST,
-                        status: Task::Status::SUBMITTED)
-    Hathitrust.new.check_async(task)
-  rescue => e
-    handle_error(e)
-  else
-    flash['success'] = 'HathiTrust check will begin momentarily.'
-  ensure
-    redirect_back fallback_location: tasks_path
-  end
-
-  ##
   # Responds to POST /check-internet-archive
   #
   def check_internet_archive

--- a/app/models/record_source.rb
+++ b/app/models/record_source.rb
@@ -111,6 +111,10 @@ class RecordSource
                                 record_index, num_invalid_files),
                   status: Task::Status::SUCCEEDED)
       puts task.name
+      if Rails.env.production? || Rails.env.demo?
+        hathi_trust = Hathitrust.new
+        hathi_trust.check_async(task)
+      end
     ensure
       Book.analyze_table
     end
@@ -127,9 +131,6 @@ class RecordSource
       raise 'This feature only works in production. '\
           'Elsewhere, use a rake task instead.'
     end
-
-    hathi_trust = Hathitrust.new
-    hathi_trust.check_async(task)
 
     # https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/ECS/Client.html#run_task-instance_method
     config = Configuration.instance

--- a/app/models/record_source.rb
+++ b/app/models/record_source.rb
@@ -123,10 +123,13 @@ class RecordSource
   # @return [void]
   #
   def import_async(task)
-    unless Rails.env.production? or Rails.env.demo?
+    unless Rails.env.production? or Rails.env.demo? 
       raise 'This feature only works in production. '\
           'Elsewhere, use a rake task instead.'
     end
+
+    hathi_trust = Hathitrust.new
+    hathi_trust.check_async(task)
 
     # https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/ECS/Client.html#run_task-instance_method
     config = Configuration.instance

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,5 +1,6 @@
-class Task < ApplicationRecord
+require_relative './hathitrust.rb'
 
+class Task < ApplicationRecord
   ##
   # An enum-like class.
   #
@@ -35,6 +36,7 @@ class Task < ApplicationRecord
 
   after_initialize :init
   before_save :constrain_progress, :auto_complete
+  after_save :trigger_hathitrust_check, if: :import_task_completed?
 
   def init
     self.status ||= Status::RUNNING
@@ -47,6 +49,23 @@ class Task < ApplicationRecord
       self.completed_at = Time.current
     end
   end
+
+  def import_task_completed?
+    if Rails.env.development?
+      status == Status::FAILED and service == Service::LOCAL_STORAGE
+    else 
+      status == Status::SUUCEEDED and service == Service::LOCAL_STORAGE
+    end
+  end
+
+  def trigger_hathitrust_check
+    hathi_trust = Hathitrust.new 
+    task = Task.create!(name: 'Preparing to check HathiTrust', 
+                        service: Service::HATHITRUST,
+                        status: Status::SUBMITTED)
+    hathi_trust.check_async(task)
+  end
+
 
   private
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,4 @@
-require_relative './hathitrust.rb'
+
 
 class Task < ApplicationRecord
   ##
@@ -36,7 +36,6 @@ class Task < ApplicationRecord
 
   after_initialize :init
   before_save :constrain_progress, :auto_complete
-  after_save :trigger_hathitrust_check, if: :import_task_completed?
 
   def init
     self.status ||= Status::RUNNING
@@ -49,27 +48,6 @@ class Task < ApplicationRecord
       self.completed_at = Time.current
     end
   end
-
-  def import_task_completed?
-    if Rails.env.production? or Rails.env.demo?
-      status == Status::SUCCEEDED and service == Service::LOCAL_STORAGE
-    else
-      status == Status::FAILED and service == Service::LOCAL_STORAGE
-    end
-  end
-
-  def trigger_hathitrust_check
-    hathi_trust = Hathitrust.new 
-    task = Task.create!(name: 'Preparing to check HathiTrust', 
-                        service: Service::HATHITRUST,
-                        status: Status::SUBMITTED)
-    if Rails.env.prorduction? or Rails.env.demo? 
-      hathi_trust.check_async(task)
-    else 
-      "This feature is not available in development mode"
-    end
-  end
-
 
   private
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -51,10 +51,10 @@ class Task < ApplicationRecord
   end
 
   def import_task_completed?
-    if Rails.env.development?
+    if Rails.env.production? or Rails.env.demo?
+      status == Status::SUCCEEDED and service == Service::LOCAL_STORAGE
+    else
       status == Status::FAILED and service == Service::LOCAL_STORAGE
-    else 
-      status == Status::SUUCEEDED and service == Service::LOCAL_STORAGE
     end
   end
 
@@ -63,7 +63,11 @@ class Task < ApplicationRecord
     task = Task.create!(name: 'Preparing to check HathiTrust', 
                         service: Service::HATHITRUST,
                         status: Status::SUBMITTED)
-    hathi_trust.check_async(task)
+    if Rails.env.prorduction? or Rails.env.demo? 
+      hathi_trust.check_async(task)
+    else 
+      "This feature is not available in development mode"
+    end
   end
 
 

--- a/app/views/tasks/index.html.haml
+++ b/app/views/tasks/index.html.haml
@@ -6,7 +6,7 @@
 
 .alert.alert-light
   %i.fa.fa-info-circle
-  Importing records will automatically start the process to check HathiTrust and Internet Archive services.
+  Importing records will automatically start the process to check HathiTrust service.
 
 %table.table
   %tr

--- a/app/views/tasks/index.html.haml
+++ b/app/views/tasks/index.html.haml
@@ -6,8 +6,7 @@
 
 .alert.alert-light
   %i.fa.fa-info-circle
-  Import records first. Once that task is complete, check the other services
-  concurrently or in any order.
+  Importing records will automatically start the process to check HathiTrust and Internet Archive services.
 
 %table.table
   %tr
@@ -32,9 +31,6 @@
         = local_time_ago(@last_ht_check.completed_at)
       - else
         Never checked
-    %td
-      = form_tag(check_hathitrust_path, method: 'post') do
-        = submit_tag('Check', class: 'btn btn-primary btn-sm')
   %tr
     %td Internet Archive
     %td
@@ -44,8 +40,6 @@
       - else
         Never checked
     %td
-      = form_tag(check_internet_archive_path, method: 'post') do
-        = submit_tag('Check', class: 'btn btn-primary btn-sm')
   %tr
     %td Google
     %td

--- a/app/views/tasks/index.html.haml
+++ b/app/views/tasks/index.html.haml
@@ -40,6 +40,8 @@
       - else
         Never checked
     %td
+      = form_tag(check_internet_archive_path, method: 'post') do
+        = submit_tag('Check', class: 'btn btn-primary btn-sm')
   %tr
     %td Google
     %td

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,8 +12,6 @@ Rails.application.routes.draw do
 
   match 'check-google', to: 'tasks#check_google', via: :post,
         as: 'check_google'
-  match 'check-hathitrust', to: 'tasks#check_hathitrust', via: :post,
-        as: 'check_hathitrust'
   match 'check-internet-archive', to: 'tasks#check_internet_archive',
         via: :post, as: 'check_internet_archive'
   match 'import', to: 'tasks#import', via: :post

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -32,21 +32,6 @@ class TasksControllerTest < ActionDispatch::IntegrationTest
     assert_equal "/check-google", request.path 
   end
 
-  test "should conduct a Hathitrust check" do
-    
-    post check_hathitrust_url
-
-    assert_equal 200, response.status
-  end
-  
-  test "should redirect back to '/check-hathitrust' after conducting Hathitrust check" do 
-    
-    post check_hathitrust_url
-    
-    assert_equal "/check-hathitrust", request.path 
-    
-  end
-
   test "should conduct a Internet Archive check" do 
 
     post check_internet_archive_url 

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -42,23 +42,6 @@ class TaskTest < ActiveSupport::TestCase
     assert_equal 3, task.service 
   end
 
-  test ".import_task_completed? will return true under correct conditions" do 
-    task = Task.new 
-    task.status=(4)
-    task.service=(Service::LOCAL_STORAGE) 
-
-    assert_equal true, task.import_task_completed?
-  end
-
-  test ".trigger_hathitrust_check will start the hathitrust check process" do 
-    task = Task.new
-    task.status=(4)
-    task.service=(Service::LOCAL_STORAGE)
-    task.import_task_completed?
-
-    assert_not_nil task.trigger_hathitrust_check
-  end
-
 end
 
 

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -20,6 +20,48 @@ class TaskTest < ActiveSupport::TestCase
   test "Status::to_s returns 'Failed' for FAILED status" do 
     assert_equal 'Failed', Task::Status.to_s(Task::Status::FAILED)
   end
+
+  test "Task.new creates new task object defaulting to status of 'RUNNING' (1) and service of nil" do 
+    task = Task.new 
+
+    assert_equal 1, task.status
+    assert_nil task.service 
+  end
+
+  test "Status can be equal to SUCCEEDED (3)" do 
+    task = Task.new 
+    task.status=(3)
+
+    assert_equal 3, task.status 
+  end
+
+  test "Service can be set to equal LOCAL_STORAGE" do 
+    task = Task.new 
+    task.service=(Service::LOCAL_STORAGE)
+
+    assert_equal 3, task.service 
+  end
+
+  test ".import_task_completed? will return true under correct conditions" do 
+    task = Task.new 
+    task.status=(4)
+    task.service=(Service::LOCAL_STORAGE) 
+
+    assert_equal true, task.import_task_completed?
+  end
+
+  test ".trigger_hathitrust_check will start the hathitrust check process" do 
+    task = Task.new
+    task.status=(4)
+    task.service=(Service::LOCAL_STORAGE)
+    task.import_task_completed?
+
+    assert_not_nil task.trigger_hathitrust_check
+  end
+
 end
+
+
+
 
 


### PR DESCRIPTION
This PR includes: 

1. code to trigger the `hathitrust check` right after import is done, removing the need to manually click the hathitrust 'check' button
2. unit tests of the new methods

For in-depth explanation of how this was tested in `local/development environment`, please see my comment [here](https://github.com/medusa-project/book-tracker/issues/6#issuecomment-1828668964)

Summary of changes:

- inside the `import_async(task)` method in `app/models/record_source.rb`, instantiates a new `hathitrust object`, which then has the task passed through the hathitrust object's `check_async()` method
- requires path to `Hathitrust model` inside the `Task model`
- inside `Task model`, includes a new callback (`after_save`) that first checks **if the import is completed** before **triggering the hathitrust check**
- inside `Task model`, adds two new methods: 

    1. `import_task_completed?` which includes logic for checking the `status `and `service` of the task. If the environment is in `prod/demo`, the status it looks for is `SUCCEEDED`. The service it looks for is `LOCAL STORAGE`.
    2. `triggers_hathitrust_check(task)`, which instantiates a new `hathitrust object`, **creates a new task** (with service equal to `Hathitrust `and service equal to `SUBMITTED`), and passes that newly created task inside the `check_async() `method. In `prod/demo` this should trigger the hathitrust check process; in development, some tweaking will be required, such as calling on the `check() `method and commenting out the `Book.analyze_table` method inside the `Hathitrust` model. 

    **This tweak should ONLY be done to see how this works in development, and should not be in the production code.** 

- inside `app/views/tasks/_tasks.html.haml`, the button to run the Hathitrust check is **removed** completely, and the **alert notice** at the top points to this change:

<img width="1074" alt="Screenshot 2023-11-27 at 1 06 13 PM" src="https://github.com/medusa-project/book-tracker/assets/103534307/cb284ee5-356f-4766-a6f7-5c48308d493a">

- adds several new tests inside `test/models/task_test.rb`, which looks at how a Task object is created upon default, and how the new methods affect those attributes. All tests pass, and existing tests don't break with the new changes:

<img width="514" alt="Screenshot 2023-11-28 at 2 12 24 PM" src="https://github.com/medusa-project/book-tracker/assets/103534307/4c8546f0-b7a4-47af-88ab-63ffa6e2057d">



