### PR TITLE
Automate Internet Archive Check

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -37,22 +37,6 @@ class TasksController < ApplicationController
   end
 
   ##
-  # Responds to POST /check-internet-archive
-  #
-  def check_internet_archive
-    task = Task.create!(name: 'Preparing to check Internet Archive',
-                        service: Service::INTERNET_ARCHIVE,
-                        status: Task::Status::SUBMITTED)
-    InternetArchive.new.check_async(task)
-  rescue => e
-    handle_error(e)
-  else
-    flash['success'] = 'Internet Archive check will begin momentarily.'
-  ensure
-    redirect_back fallback_location: tasks_path
-  end
-
-  ##
   # Responds to POST /import
   #
   def import

--- a/app/models/record_source.rb
+++ b/app/models/record_source.rb
@@ -113,11 +113,9 @@ class RecordSource
       puts task.name
       if Rails.env.production? || Rails.env.demo?
         hathi_trust = Hathitrust.new
+        ia = InternetArchive.new 
         hathi_trust.check_async(task)
-        if hathi_trust.check_async(task)
-          ia = InternetArchive.new 
-          ia.check_async(task)
-        end
+        ia.check_async(task)
       end
     ensure
       Book.analyze_table

--- a/app/models/record_source.rb
+++ b/app/models/record_source.rb
@@ -114,6 +114,10 @@ class RecordSource
       if Rails.env.production? || Rails.env.demo?
         hathi_trust = Hathitrust.new
         hathi_trust.check_async(task)
+        if hathi_trust.check_async(task)
+          ia = InternetArchive.new 
+          ia.check_async(task)
+        end
       end
     ensure
       Book.analyze_table

--- a/app/views/tasks/index.html.haml
+++ b/app/views/tasks/index.html.haml
@@ -40,8 +40,6 @@
       - else
         Never checked
     %td
-      = form_tag(check_internet_archive_path, method: 'post') do
-        = submit_tag('Check', class: 'btn btn-primary btn-sm')
   %tr
     %td Google
     %td

--- a/app/views/tasks/index.html.haml
+++ b/app/views/tasks/index.html.haml
@@ -6,7 +6,7 @@
 
 .alert.alert-light
   %i.fa.fa-info-circle
-  Importing records will automatically start the process to check HathiTrust service.
+  Importing records will automatically start the process to check HathiTrust and Internet Archive services.
 
 %table.table
   %tr

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,8 +12,6 @@ Rails.application.routes.draw do
 
   match 'check-google', to: 'tasks#check_google', via: :post,
         as: 'check_google'
-  match 'check-internet-archive', to: 'tasks#check_internet_archive',
-        via: :post, as: 'check_internet_archive'
   match 'import', to: 'tasks#import', via: :post
 
   match '/', to: redirect('/books'), via: :get, as: 'root'

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -31,18 +31,4 @@ class TasksControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal "/check-google", request.path 
   end
-
-  test "should conduct a Internet Archive check" do 
-
-    post check_internet_archive_url 
-
-    assert_equal 200, response.status 
-  end
-
-  test "should redirect back to '/check-internet-archive' after conducting IA check" do 
-
-    post check_internet_archive_url
-
-    assert_equal "/check-internet-archive", request.path 
-  end
 end


### PR DESCRIPTION
Similar to [PR 37](https://github.com/medusa-project/book-tracker/pull/37):

- Adds `IA instance` inside the `RecordSource.import()` method  - I wanted to make sure that `IA check` can only run if `Hathi check` has been completed first, so there's an `if block` nested inside another `if block`. 
- Removes the `check_ia_path` from the `routes, Tasks Controller, and associated tests`
- Removes the `IA check button`
- Updates the `alert/info` about how the import/checks work