### PR TITLE
Allow usage of OCLC numbers as identifiers

### DIFF
--- a/app/views/books/_book_rows.html.haml
+++ b/app/views/books/_book_rows.html.haml
@@ -2,6 +2,7 @@
   %tr
     %td= link_to(book.bib_id, book)
     %td= book.obj_id
+    %td= book.oclc_number
     %td= link_to(book.title, book)
     %td= book.volume
     %td= book.author

--- a/app/views/books/_books.html.haml
+++ b/app/views/books/_books.html.haml
@@ -3,6 +3,7 @@
     %tr
       %th Bib ID
       %th Object ID
+      %th OCLC Number
       %th Title
       %th Volume
       %th Author

--- a/app/views/books/index.html.haml
+++ b/app/views/books/index.html.haml
@@ -75,7 +75,7 @@
         .col-sm-3
           = hidden_field_tag(:ht, params[:ht])
           = hidden_field_tag(:ia, params[:ia])
-          = text_area_tag(:q, params[:q], placeholder: 'Filter by term or list of bib or object IDs',
+          = text_area_tag(:q, params[:q], placeholder: 'Filter by term, list of bib, object IDs or OCLC number',
                                class: 'form-control', rows: 4, style: 'width:100%')
           .float-right
             .btn-group

--- a/test/controllers/books_controller_test.rb
+++ b/test/controllers/books_controller_test.rb
@@ -12,7 +12,7 @@ class BooksControllerTest < ActionDispatch::IntegrationTest
     assert_equal 200, response.status 
   end
 
-  test "can filter by bib id, object id, or oclc number" do 
+  test "can filter by oclc number" do 
     @b6 = books(:six)
     @b5 = books(:five)
     @b4 = books(:four)
@@ -26,6 +26,23 @@ class BooksControllerTest < ActionDispatch::IntegrationTest
     oclc_numbers = lines.map(&:strip).select{ |id| id.length == 8 }
 
     filtered_books = @books.select{|b| oclc_numbers.include?(b.oclc_number)}
+    assert_equal filtered_books, [@b5, @b6]
+  end
+
+  test "can filter by bib_id" do 
+    @b6 = books(:six)
+    @b5 = books(:five)
+    @b4 = books(:four)
+
+    @books = [@b4, @b5, @b6]
+
+    get books_url 
+
+    query = "#{@b6.bib_id}\n#{@b5.bib_id}"
+    lines = query.strip.split("\n")
+    bib_ids = lines.map(&:strip).select{ |id| id.length < 8 }
+    bib_ids_i = bib_ids.map{|b| b.to_i}
+    filtered_books = @books.select{|b| bib_ids_i.include?(b.bib_id)}
 
     assert_equal filtered_books, [@b5, @b6]
   end

--- a/test/controllers/books_controller_test.rb
+++ b/test/controllers/books_controller_test.rb
@@ -19,14 +19,15 @@ class BooksControllerTest < ActionDispatch::IntegrationTest
 
     @books = [@b4, @b5, @b6]
 
-    get books_url 
-
     query = "#{@b6.oclc_number}\n#{@b5.oclc_number}"
-    lines = query.strip.split("\n")
-    oclc_numbers = lines.map(&:strip).select{ |id| id.length == 8 }
 
-    filtered_books = @books.select{|b| oclc_numbers.include?(b.oclc_number)}
-    assert_equal filtered_books, [@b5, @b6]
+    get books_url(q: query, format: :json)
+
+    response_body = JSON.parse(response.body)
+
+    assert_equal 2, response_body['numResults']
+    assert_equal @b6.oclc_number, response_body['results'][0]['oclc_number']
+    assert_equal @b5.oclc_number, response_body['results'][1]['oclc_number']
   end
 
   test "can filter by object_id" do 
@@ -36,15 +37,14 @@ class BooksControllerTest < ActionDispatch::IntegrationTest
 
     @books = [@b4, @b5, @b6]
 
-    get books_url 
-
     query = "#{@b6.obj_id}\n#{@b5.obj_id}"
-    lines = query.strip.split("\n")
-    obj_ids = lines.map{ |x| x.strip[0..20] }.select{ |id| id.length > 8 }
 
-    filtered_books = @books.select{|b| obj_ids.include?(b.obj_id)}
-    
-    assert_equal filtered_books, [@b5, @b6]
+    get books_url(q: query, format: :json)
+
+    response_body = JSON.parse(response.body)
+
+    assert_equal @b6.obj_id, response_body['results'][0]['obj_id']
+    assert_equal @b5.obj_id, response_body['results'][1]['obj_id']
   end
 
   test "can filter by bib_id" do 
@@ -54,15 +54,14 @@ class BooksControllerTest < ActionDispatch::IntegrationTest
 
     @books = [@b4, @b5, @b6]
 
-    get books_url 
-
     query = "#{@b6.bib_id}\n#{@b5.bib_id}"
-    lines = query.strip.split("\n")
-    bib_ids = lines.map(&:strip).select{ |id| id.length < 8 }
-    bib_ids_i = bib_ids.map{|b| b.to_i}
-    filtered_books = @books.select{|b| bib_ids_i.include?(b.bib_id)}
+    
+    get books_url(q: query, format: :json)
 
-    assert_equal filtered_books, [@b5, @b6]
+    response_body = JSON.parse(response.body)
+
+    assert_equal @b6.bib_id, response_body['results'][0]['bib_id']
+    assert_equal @b5.bib_id, response_body['results'][1]['bib_id']
   end
   
   test "return http 200 status request for any particular book" do

--- a/test/controllers/books_controller_test.rb
+++ b/test/controllers/books_controller_test.rb
@@ -12,6 +12,24 @@ class BooksControllerTest < ActionDispatch::IntegrationTest
     assert_equal 200, response.status 
   end
 
+  test "can filter by bib id, object id, or oclc number" do 
+    @b6 = books(:six)
+    @b5 = books(:five)
+    @b4 = books(:four)
+
+    @books = [@b4, @b5, @b6]
+
+    get books_url 
+
+    query = "#{@b6.oclc_number}\n#{@b5.oclc_number}"
+    lines = query.strip.split("\n")
+    oclc_numbers = lines.map(&:strip).select{ |id| id.length == 8 }
+
+    filtered_books = @books.select{|b| oclc_numbers.include?(b.oclc_number)}
+
+    assert_equal filtered_books, [@b5, @b6]
+  end
+  
   test "return http 200 status request for any particular book" do
     get book_url(@book)
 

--- a/test/controllers/books_controller_test.rb
+++ b/test/controllers/books_controller_test.rb
@@ -29,6 +29,24 @@ class BooksControllerTest < ActionDispatch::IntegrationTest
     assert_equal filtered_books, [@b5, @b6]
   end
 
+  test "can filter by object_id" do 
+    @b6 = books(:six)
+    @b5 = books(:five)
+    @b4 = books(:four)
+
+    @books = [@b4, @b5, @b6]
+
+    get books_url 
+
+    query = "#{@b6.obj_id}\n#{@b5.obj_id}"
+    lines = query.strip.split("\n")
+    obj_ids = lines.map{ |x| x.strip[0..20] }.select{ |id| id.length > 8 }
+
+    filtered_books = @books.select{|b| obj_ids.include?(b.obj_id)}
+    
+    assert_equal filtered_books, [@b5, @b6]
+  end
+
   test "can filter by bib_id" do 
     @b6 = books(:six)
     @b5 = books(:five)


### PR DESCRIPTION
This PR is for issue #8 

Summary of Changes:

- Modify placeholder in search box to include filtering by `oclc number(s)`
<img width="1108" alt="Screenshot 2024-01-17 at 10 42 10 AM" src="https://github.com/medusa-project/book-tracker/assets/103534307/0ba3066c-5609-4042-b0a8-16806826eb44">

- Include `oclc_number` in table results

<img width="1059" alt="Screenshot 2024-01-17 at 10 43 26 AM" src="https://github.com/medusa-project/book-tracker/assets/103534307/27661f4d-2eb2-45ca-beaa-df8367435e84">

- Update `BooksController#index` to query for oclc_numbers (which are found by setting `id.length == 8`)
- Include oclc_number for `compiling missing ids`
- Add `'OR oclc_number = ?'` in SQL query to find matching book records 
<img width="1355" alt="Screenshot 2024-01-17 at 10 59 22 AM" src="https://github.com/medusa-project/book-tracker/assets/103534307/be5b5cbb-8973-455b-9ad5-36dce59b9679">


- Tests for each of the different `filtering queries` (bib, object, oclc)