### PR TITLE
Book Cover Images

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -7,7 +7,7 @@ class TasksController < ApplicationController
   before_action :authorize_hathitrust_check, only: :check_hathitrust
   before_action :authorize_internet_archive_check, only: :check_internet_archive
   before_action :check_production, except: :index
-
+  
   ##
   # Responds to POST /check-google
   #

--- a/app/views/books/show.html.haml
+++ b/app/views/books/show.html.haml
@@ -15,6 +15,7 @@
           %br
           %small.date= @book.date
 
+
   .col-sm-3
     .btn-group.float-right{role: 'group'}
       .btn-group{role: 'group'}
@@ -46,6 +47,7 @@
       %h5.card-header Info
       .card-body
         %dl
+          <img src="http://covers.openlibrary.org/b/oclc/#{@book.oclc_number}-M.jpg" alt="Book cover" class="center">
           %dt Bib ID
           %dd= @book.bib_id
           %dt Object ID

--- a/db/migrate/20240124223528_add_cover_filename_to_books.rb
+++ b/db/migrate/20240124223528_add_cover_filename_to_books.rb
@@ -1,0 +1,6 @@
+class AddCoverFilenameToBooks < ActiveRecord::Migration[7.1]
+  def change
+    add_column :books, :cover_filename, :string
+    add_index :books, :cover_filename
+  end
+end

--- a/db/migrate/20240124223528_add_cover_filename_to_books.rb
+++ b/db/migrate/20240124223528_add_cover_filename_to_books.rb
@@ -1,6 +1,5 @@
 class AddCoverFilenameToBooks < ActiveRecord::Migration[7.1]
   def change
     add_column :books, :cover_filename, :string
-    add_index :books, :cover_filename
   end
 end

--- a/db/migrate/20240124223528_add_cover_filename_to_books.rb
+++ b/db/migrate/20240124223528_add_cover_filename_to_books.rb
@@ -1,5 +1,0 @@
-class AddCoverFilenameToBooks < ActiveRecord::Migration[7.1]
-  def change
-    add_column :books, :cover_filename, :string
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_24_223528) do
+ActiveRecord::Schema[7.1].define(version: 2022_09_16_162423) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -34,7 +34,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_24_223528) do
     t.text "raw_marcxml"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.string "cover_filename"
     t.index ["author"], name: "index_books_on_author"
     t.index ["bib_id"], name: "index_books_on_bib_id"
     t.index ["date"], name: "index_books_on_date"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -37,7 +37,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_24_223528) do
     t.string "cover_filename"
     t.index ["author"], name: "index_books_on_author"
     t.index ["bib_id"], name: "index_books_on_bib_id"
-    t.index ["cover_filename"], name: "index_books_on_cover_filename"
     t.index ["date"], name: "index_books_on_date"
     t.index ["exists_in_google"], name: "index_books_on_exists_in_google"
     t.index ["exists_in_hathitrust", "exists_in_internet_archive", "exists_in_google"], name: "index_books_on_service_existence_columns"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_16_162423) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_24_223528) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -34,8 +34,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_16_162423) do
     t.text "raw_marcxml"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.string "cover_filename"
     t.index ["author"], name: "index_books_on_author"
     t.index ["bib_id"], name: "index_books_on_bib_id"
+    t.index ["cover_filename"], name: "index_books_on_cover_filename"
     t.index ["date"], name: "index_books_on_date"
     t.index ["exists_in_google"], name: "index_books_on_exists_in_google"
     t.index ["exists_in_hathitrust", "exists_in_internet_archive", "exists_in_google"], name: "index_books_on_service_existence_columns"

--- a/lib/tasks/books.rake
+++ b/lib/tasks/books.rake
@@ -26,33 +26,5 @@ namespace :books do
     t = args[:task_id].present? ? Task.find(args[:task_id]) : nil
     InternetArchive.new.check(t)
   end
-
-  desc 'Iterates through books to make request to open library api and download/store image to s3 bucket.'
-  task :download_book_covers, [:task_id] => :environment do 
-    require 'net/http'
-
-    # loads prior Rails tasks and entire application code needed for new rake task to interact // 
-    # this ensures pry session is hit
-    Rails.application.load_tasks 
-    Rails.application.eager_load!
-
-    
-    s3 = Aws::S3::Client.new(
-      access_key_id: Configuration.instance.storage[:books][:access_key_id],
-      secret_access_key: Configuration.instance.storage[:books][:secret_access_key],
-      region: Configuration.instance.storage[:books][:region]
-    )
-    Book.all.each do |book|
-      uri = URI("http://covers.openlibrary.org/b/oclc/#{book.oclc_number}-L.jpg")
-      response = Net::HTTP.get_response(uri)
-      
-      s3.put_object(
-        bucket: Configuration.instance.storage[:books][:bucket],
-        key: "book_covers/#{book.oclc_number}.jpg",
-        body: response.body 
-      )
-      require 'pry'; binding.pry 
-    end
-  end
-
+  
 end


### PR DESCRIPTION
PR for Issue #11 

- Uses OpenLibrary API to retrieve a book's cover image based on OCLC number
- Inserts img element inside book show page:

<img width="1324" alt="Screenshot 2024-01-31 at 10 25 33 AM" src="https://github.com/medusa-project/book-tracker/assets/103534307/a36c7638-3f9c-4ee0-8088-0056feffeac6">

- The show page is left unaltered if there is no cover image associated with a book

<img width="1422" alt="Screenshot 2024-01-31 at 10 27 07 AM" src="https://github.com/medusa-project/book-tracker/assets/103534307/dcd472d1-1111-4cac-aa5b-62a945057ad3">
