### PR TITLE
Refactoring/DRYing up code

### DIFF
--- a/app/models/google.rb
+++ b/app/models/google.rb
@@ -7,6 +7,7 @@
 # Gorman (jtgorman@illinois.edu) in Library IT to request access.
 #
 class Google
+  include Syncable
 
   TASK_UPDATE_INTERVAL = 1000
   UPDATE_BATCH_SIZE    = 1000
@@ -108,36 +109,8 @@ class Google
   # @param task [Task]
   # @return [void]
   #
-  def check_async(task)
-    unless Rails.env.production? or Rails.env.demo?
-      raise 'This feature only works in production. '\
-          'Elsewhere, use a rake task instead.'
-    end
-
-    # https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/ECS/Client.html#run_task-instance_method
-    config = Configuration.instance
-    ecs = Aws::ECS::Client.new
-    args = {
-        cluster: config.ecs_cluster,
-        task_definition: config.ecs_async_task_definition,
-        launch_type: 'FARGATE',
-        overrides: {
-            container_overrides: [
-                {
-                    name: config.ecs_async_task_container,
-                    command: ['bin/rails', "books:check_google[#{@inventory_key},#{task.id}]"]
-                },
-            ]
-        },
-        network_configuration: {
-            awsvpc_configuration: {
-                subnets: [config.ecs_subnet],
-                security_groups: [config.ecs_security_group],
-                assign_public_ip: 'ENABLED'
-            },
-        }
-    }
-    ecs.run_task(args)
+  def check_async
+    run_task(:google, task)
   end
 
   private

--- a/app/models/google.rb
+++ b/app/models/google.rb
@@ -102,12 +102,8 @@ class Google
       store.delete_object(bucket: bucket, key: @inventory_key)
     end
   end
-
   ##
-  # Invokes a rake task via an ECS task to check the service.
-  #
-  # @param task [Task]
-  # @return [void]
+  # calls on Syncable module run_task() method to invoke rake task
   #
   def check_async(task)
     run_task(:google, task)

--- a/app/models/google.rb
+++ b/app/models/google.rb
@@ -109,7 +109,7 @@ class Google
   # @param task [Task]
   # @return [void]
   #
-  def check_async
+  def check_async(task)
     run_task(:google, task)
   end
 

--- a/app/models/hathitrust.rb
+++ b/app/models/hathitrust.rb
@@ -97,7 +97,7 @@ class Hathitrust
   # @param task [Task]
   # @return [void]
   #
-  def check_async
+  def check_async(task)
     run_task(:hathitrust, task)
   end
 

--- a/app/models/hathitrust.rb
+++ b/app/models/hathitrust.rb
@@ -92,10 +92,7 @@ class Hathitrust
   end
 
   ##
-  # Invokes a rake task via an ECS task to check the service.
-  #
-  # @param task [Task]
-  # @return [void]
+  # calls on Syncable module run_task() method to invoke rake task
   #
   def check_async(task)
     run_task(:hathitrust, task)

--- a/app/models/hathitrust.rb
+++ b/app/models/hathitrust.rb
@@ -3,6 +3,7 @@
 # local books with its findings.
 #
 class Hathitrust
+  include Syncable 
 
   ##
   # @return [Boolean] Whether an invocation of check() is authorized.
@@ -96,38 +97,9 @@ class Hathitrust
   # @param task [Task]
   # @return [void]
   #
-  def check_async(task)
-    unless Rails.env.production? or Rails.env.demo?
-      raise 'This feature only works in production. '\
-          'Elsewhere, use a rake task instead.'
-    end
-
-    # https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/ECS/Client.html#run_task-instance_method
-    config = Configuration.instance
-    ecs = Aws::ECS::Client.new
-    args = {
-        cluster: config.ecs_cluster,
-        task_definition: config.ecs_async_task_definition,
-        launch_type: 'FARGATE',
-        overrides: {
-            container_overrides: [
-                {
-                    name: config.ecs_async_task_container,
-                    command: ['bin/rails', "books:check_hathitrust[#{task.id}]"]
-                },
-            ]
-        },
-        network_configuration: {
-            awsvpc_configuration: {
-                subnets: [config.ecs_subnet],
-                security_groups: [config.ecs_security_group],
-                assign_public_ip: 'ENABLED'
-            },
-        }
-    }
-    ecs.run_task(args)
+  def check_async
+    run_task(:hathitrust, task)
   end
-
 
   private
   

--- a/app/models/internet_archive.rb
+++ b/app/models/internet_archive.rb
@@ -77,16 +77,11 @@ class InternetArchive
       set_existing(ia_id_batch)
     end
   end
-
   ##
-  # Invokes a rake task via an ECS task to check the service.
-  #
-  # @param task [Task]
-  # @return [void]
+  # calls on Syncable module run_task() method to invoke rake task
   #
   def check_async(task)
     run_task(:internet_archive, task)
-     
   end
 
   private

--- a/app/models/internet_archive.rb
+++ b/app/models/internet_archive.rb
@@ -84,8 +84,9 @@ class InternetArchive
   # @param task [Task]
   # @return [void]
   #
-  def check_async
+  def check_async(task)
     run_task(:internet_archive, task)
+     
   end
 
   private

--- a/app/models/internet_archive.rb
+++ b/app/models/internet_archive.rb
@@ -3,6 +3,7 @@
 # corresponding local books with its findings.
 #
 class InternetArchive
+  include Syncable 
 
   TASK_UPDATE_INTERVAL = 1000
   UPDATE_BATCH_SIZE    = 1000

--- a/app/models/internet_archive.rb
+++ b/app/models/internet_archive.rb
@@ -83,36 +83,8 @@ class InternetArchive
   # @param task [Task]
   # @return [void]
   #
-  def check_async(task)
-    unless Rails.env.production? or Rails.env.demo?
-      raise 'This feature only works in production. '\
-          'Elsewhere, use a rake task instead.'
-    end
-
-    # https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/ECS/Client.html#run_task-instance_method
-    config = Configuration.instance
-    ecs = Aws::ECS::Client.new
-    args = {
-        cluster: config.ecs_cluster,
-        task_definition: config.ecs_async_task_definition,
-        launch_type: 'FARGATE',
-        overrides: {
-            container_overrides: [
-                {
-                    name: config.ecs_async_task_container,
-                    command: ['bin/rails', "books:check_internet_archive[#{task.id}]"]
-                },
-            ]
-        },
-        network_configuration: {
-            awsvpc_configuration: {
-                subnets: [config.ecs_subnet],
-                security_groups: [config.ecs_security_group],
-                assign_public_ip: 'ENABLED'
-            },
-        }
-    }
-    ecs.run_task(args)
+  def check_async
+    run_task(:internet_archive, task)
   end
 
   private

--- a/app/models/record_source.rb
+++ b/app/models/record_source.rb
@@ -2,7 +2,8 @@
 # Source of MARCXML records--currently an S3 bucket.
 #
 class RecordSource
-
+  include Syncable 
+  
   INSERT_BATCH_SIZE = 100
   MARCXML_NAMESPACES = { 'marc' => 'http://www.loc.gov/MARC21/slim' }
 

--- a/app/models/record_source.rb
+++ b/app/models/record_source.rb
@@ -132,15 +132,11 @@ class RecordSource
       Book.analyze_table
     end
   end
-
   ##
-  # Invokes a rake task via an ECS task to import records.
-  #
-  # @param task [Task]
-  # @return [void]
-  #
+  # calls on Syncable module run_task() method to invoke rake task
+  # 
   def import_async(task)
-    run_task(:record_source, task)
+    run_task(:record_source, task) 
   end
   
   private

--- a/app/models/record_source.rb
+++ b/app/models/record_source.rb
@@ -3,7 +3,7 @@
 #
 class RecordSource
   include Syncable 
-  
+
   INSERT_BATCH_SIZE = 100
   MARCXML_NAMESPACES = { 'marc' => 'http://www.loc.gov/MARC21/slim' }
 
@@ -139,10 +139,10 @@ class RecordSource
   # @param task [Task]
   # @return [void]
   #
-  def import_async
+  def import_async(task)
     run_task(:record_source, task)
   end
-
+  
   private
 
   def upsert(batch)

--- a/app/models/record_source.rb
+++ b/app/models/record_source.rb
@@ -138,36 +138,8 @@ class RecordSource
   # @param task [Task]
   # @return [void]
   #
-  def import_async(task)
-    unless Rails.env.production? or Rails.env.demo? 
-      raise 'This feature only works in production. '\
-          'Elsewhere, use a rake task instead.'
-    end
-
-    # https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/ECS/Client.html#run_task-instance_method
-    config = Configuration.instance
-    ecs = Aws::ECS::Client.new
-    args = {
-        cluster: config.ecs_cluster,
-        task_definition: config.ecs_async_task_definition,
-        launch_type: 'FARGATE',
-        overrides: {
-            container_overrides: [
-                {
-                    name: config.ecs_async_task_container,
-                    command: ['bin/rails', "books:import[#{task.id}]"]
-                },
-            ]
-        },
-        network_configuration: {
-            awsvpc_configuration: {
-                subnets: [config.ecs_subnet],
-                security_groups: [config.ecs_security_group],
-                assign_public_ip: 'ENABLED'
-            },
-        }
-    }
-    ecs.run_task(args)
+  def import_async
+    run_task(:record_source, task)
   end
 
   private

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,8 @@ module BookTracker
 
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
+    config.autoload_paths += %W(#{config.root}/lib)
+
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/lib/syncable.rb
+++ b/lib/syncable.rb
@@ -1,5 +1,12 @@
 module Syncable
+  ##
+  # Invokes a rake task via an ECS task to check the service.
+  #
+  # @param task [Task]
+  # @return [void]
+  #
   def run_task(model, task)
+
     unless Rails.env.production? or Rails.env.demo? 
       raise 'This feature only works in production. '\
           'Elsewhere, use a rake task instead.'

--- a/lib/syncable.rb
+++ b/lib/syncable.rb
@@ -1,0 +1,50 @@
+module Syncable
+  def run_task(model, task)
+    unless Rails.env.production? or Rails.env.demo?
+      raise 'This feature only works in production. '\
+          'Elsewhere, use a rake task instead.'
+    end
+    # https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/ECS/Client.html#run_task-instance_method
+    config = Configuration.instance
+    ecs = Aws::ECS::Client.new
+
+    command = generate_command(model, task)
+
+    args = {
+        cluster: config.ecs_cluster,
+        task_definition: config.ecs_async_task_definition,
+        launch_type: 'FARGATE',
+        overrides: {
+            container_overrides: [
+                {
+                    name: config.ecs_async_task_container,
+                    command: command 
+                },
+            ]
+        },
+        network_configuration: {
+            awsvpc_configuration: {
+                subnets: [config.ecs_subnet],
+                security_groups: [config.ecs_security_group],
+                assign_public_ip: 'ENABLED'
+            },
+        }
+    }
+    ecs.run_task(args)
+  end
+
+  private 
+
+  def generate_command(model, task)
+    case model 
+      when :internet_archive 
+        ['bin/rails', "books:check_internet_archive[#{task.id}]"]
+      when :hathitrust 
+        ['bin/rails', "books:check_hathitrust[#{task.id}]"]
+      when :google
+        ['bin/rails', "books:check_google[#{@inventory_key},#{task.id}]"]
+      else 
+        ['bin/rails', "books:import[#{task.id}]"]
+    end
+  end
+end

--- a/lib/syncable.rb
+++ b/lib/syncable.rb
@@ -50,8 +50,10 @@ module Syncable
         ['bin/rails', "books:check_hathitrust[#{task.id}]"]
       when :google
         ['bin/rails', "books:check_google[#{@inventory_key},#{task.id}]"]
-      else 
+      when :record_source  
         ['bin/rails', "books:import[#{task.id}]"]
+      else
+        "no such model"
     end
   end
 end

--- a/lib/syncable.rb
+++ b/lib/syncable.rb
@@ -53,7 +53,7 @@ module Syncable
       when :record_source  
         ['bin/rails', "books:import[#{task.id}]"]
       else
-        "no such model"
+        raise 'No such model'
     end
   end
 end

--- a/lib/syncable.rb
+++ b/lib/syncable.rb
@@ -1,13 +1,13 @@
 module Syncable
   def run_task(model, task)
-    unless Rails.env.production? or Rails.env.demo?
+    unless Rails.env.production? or Rails.env.demo? 
       raise 'This feature only works in production. '\
           'Elsewhere, use a rake task instead.'
     end
+
     # https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/ECS/Client.html#run_task-instance_method
     config = Configuration.instance
     ecs = Aws::ECS::Client.new
-
     command = generate_command(model, task)
 
     args = {


### PR DESCRIPTION
This PR is for issue #50 , handling duplicate code for the `.check_async()` and `.import_async()` methods across different models. 

Summary of Changes - 

- Creation of a `module` (inside `lib` directory) that hosts a `run_task()` method. This method takes in a `model and a task`, and contains the code that is shared among all the models in `invoking a rake task via ECS task` to check each service. 
- A private method, `generate_command()` was created to hold the logic of what the `command` should be, depending on which model the check is for. 
- The `generate_command()` method takes in a `model` and `task`, and uses a `case statement` to assign the correct command depending on the service/model.
- Inside each model the `check_async/import_async()` method is replaced with a call to the `Syncable module's run_task() method` with the correct parameters.

```ruby
module Syncable 
   def run_task(model, task)
       # code 
       command = generate_command(model, task)
       # code 
               overrides: {
            container_overrides: [
                {
                    name: config.ecs_async_task_container,
                    command: command 
                },
            ]
        },
      # code 
   end 
   private 
   
   def generate_command(model, task)
    case model 
      when :internet_archive 
        ['bin/rails', "books:check_internet_archive[#{task.id}]"]
      when :hathitrust 
        ['bin/rails', "books:check_hathitrust[#{task.id}]"]
      when :google
        ['bin/rails', "books:check_google[#{@inventory_key},#{task.id}]"]
      when :record_source  
        ['bin/rails', "books:import[#{task.id}]"]
      else
        "no such model"
    end
  end
end
```

- Each model includes the module to access the shared method. 

e.g. 
```ruby
class Hathitrust
  include Syncable 

  #code
  def check_async(task)
    run_task(:hathitrust, task)
  end
  #code

end
```
- In order to load the Syncable module throughout the app, `config/application.rb `needed to be updated with: 
```ruby
config.autoload_paths += %W(#{config.root}/lib}
```

- I tested this locally just by running the different bin/rails commands (ie. bin/rails books:import) to make sure nothing broke