### PR TITLE
Book count fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,4 +8,4 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v2
       - name: Run the tests
-        run: docker-compose -f docker-compose.yml -f docker-compose.test.yml up --build --exit-code-from book-tracker-test
+        run: docker compose -f docker-compose.yml -f docker-compose.test.yml up --build --exit-code-from book-tracker-test

--- a/Gemfile
+++ b/Gemfile
@@ -30,4 +30,9 @@ gem 'aws-sdk-sqs'
 
 group :development do
   gem 'listen'
+  gem 'pry', '~> 0.14.1'
+end
+
+group :test do 
+  gem 'mocha'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,7 @@ GEM
     base64 (0.1.1)
     bigdecimal (3.1.4)
     builder (3.2.4)
+    coderay (1.1.3)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -178,10 +179,13 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.2)
+    method_source (1.1.0)
     mini_mime (1.1.5)
     mini_racer (0.8.0)
       libv8-node (~> 18.16.0.0)
     minitest (5.20.0)
+    mocha (2.5.0)
+      ruby2_keywords (>= 0.0.5)
     mutex_m (0.1.2)
     net-imap (0.4.1)
       date
@@ -216,6 +220,9 @@ GEM
       racc
     pg (1.5.4)
     power_assert (2.0.3)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     psych (5.1.1)
       stringio
     puma (6.4.2)
@@ -352,10 +359,12 @@ DEPENDENCIES
   listen
   local_time
   mini_racer
+  mocha
   omniauth
   omniauth-rails_csrf_protection
   omniauth-saml
   pg
+  pry (~> 0.14.1)
   puma
   rails (~> 7)
   sassc

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -19,7 +19,9 @@ class Book < ApplicationRecord
   # queries responsive after a lot of UPDATEs.
   #
   def self.analyze_table
-    ActiveRecord::Base.connection.execute('VACUUM ANALYZE books;')
+    unless Rails.env.test?
+      ActiveRecord::Base.connection.execute('VACUUM ANALYZE books;')
+    end
   end
 
   ##
@@ -49,17 +51,19 @@ class Book < ApplicationRecord
     return unless length > 0
 
     sql = StringIO.new
-    sql << sprintf('UPDATE books SET %s = %s WHERE %s IN (',
-                   column, new_value, where_column)
+    sql << sprintf('UPDATE books SET %s = $%d WHERE %s IN (',
+                   column, length + 1, where_column)
     length.times do |index|
       sql << "$#{index + 1}"
-      if index < length - 1
-        sql << ', '
-      end
+      sql << ', ' if index < length - 1
     end
+    #   if index < length - 1
+    #     sql << ', '
+    #   end
+    # end
     sql << ');'
 
-    binds = batch
+    binds = batch + [new_value]
 
     Rails.logger.debug("Book.bulk_update(): updating #{batch.length} records")
     ActiveRecord::Base.connection.exec_query(sql.string, 'SQL', binds, prepare: true)

--- a/test/models/google_test.rb
+++ b/test/models/google_test.rb
@@ -1,0 +1,80 @@
+require 'test_helper'
+require 'mocha/minitest'
+
+class GoogleTest < ActiveSupport::TestCase
+  def setup
+    @inventory_key = 'test_inventory_key'
+    @google = Google.new(@inventory_key)
+    @task = Task.create!(name: 'Google Test Task', service: Service::GOOGLE, status: Task::Status::SUBMITTED)
+    Book.delete_all  
+
+    @gb = Book.create!(bib_id: 1, obj_id: 'test_id_1', exists_in_google: false)
+    @gb2 = Book.create!(bib_id: 2, obj_id: 'test_id_2', exists_in_google: false)
+  end
+
+  def teardown 
+    @task.destroy 
+    Book.delete_all 
+  end
+
+  test 'check should raise error if another check is in progress' do
+    Task.create!(name: 'Running Task', service: Service::GOOGLE, status: Task::Status::RUNNING)
+    assert_raises(RuntimeError, 'Another Google check is in progress.') do
+      @google.check
+    end
+  end
+
+  test 'check should create a new task if none is provided' do 
+    mock_response = Struct.new(:body).new("test_id_1\ttest_date\n" * 2)
+    mock_store = mock('TempStore')
+    mock_store.stubs(:get_object).returns(mock_response)
+    mock_store.stubs(:delete_object).with(bucket: 'book-tracker-temp-test', key: @inventory_key).returns(nil)
+    
+    TempStore.stubs(:instance).returns(mock_store)
+
+    assert_difference 'Task.count', 1 do 
+      @google.check 
+    end
+  end
+
+    test 'check should update the database with items found' do 
+      mock_response = Struct.new(:body).new("test_id_1\ttest_date\n" * 2)
+      mock_store = mock('TempStore')
+      mock_store.stubs(:get_object).returns(mock_response)
+      mock_store.stubs(:delete_object).with(bucket: 'book-tracker-temp-test', key: @inventory_key).returns(nil)
+      
+      TempStore.stubs(:instance).returns(mock_store)
+
+      @google.check
+
+      @gb.reload
+      @gb2.reload 
+
+      assert_equal 1, Book.where(exists_in_google: true).count
+      assert @gb.exists_in_google 
+      assert !@gb2.exists_in_google
+    end
+
+    # mock_store = Minitest::Mock.new 
+    # mock_store.expect :get_object, mock_response, [{ bucket: 'book-tracker-temp-test', key: @inventory_key }]
+    # mock_store.expect :get_object, mock_response, [{ bucket: 'book-tracker-temp-test', key: @inventory_key }]
+    # mock_store.expect :delete_object, nil, [{ bucket: 'book-tracker-temp-test', key: @inventory_key }]
+
+    # mock_store.expect :get_object, mock_response do |args|
+    #   puts "get_object called with: #{args}"
+    #   args.is_a?(Hash) && args[:bucket] == 'book-tracker-temp-test' && args[:key] == @inventory_key
+    # end
+    # mock_store.expect :delete_object, nil do |args|
+    #   args.is_a?(Hash) && args[:bucket] == 'book-tracker-temp-test' && args[:key] == @inventory_key
+    # end
+
+  #   TempStore.stub :instance, mock_store do
+  #     assert_difference 'Task.count', 1 do 
+  #       @google.check 
+  #     end
+  #   end
+  #   mock_store.verify 
+  # end
+
+
+end

--- a/test/models/internet_archive_test.rb
+++ b/test/models/internet_archive_test.rb
@@ -1,0 +1,60 @@
+require 'test_helper'
+require 'minitest/mock'
+
+class InternetArchiveTest < ActiveSupport::TestCase
+  def setup
+    @internet_archive = InternetArchive.new 
+    @task = Task.create!(name: 'Test Task', service: Service::INTERNET_ARCHIVE, status: Task::Status::SUBMITTED)
+    Book.delete_all
+
+    Book.create!(bib_id: 1, ia_identifier: 'test_id_1', exists_in_internet_archive: false)
+    Book.create!(bib_id: 2, ia_identifier: 'test_id_2', exists_in_internet_archive: false)
+  end
+
+  def teardown 
+    @task.destroy 
+    Book.delete_all
+  end
+
+  test 'check should update the database with items found' do
+    mock_api_results = Nokogiri::XML('<result numFound="2"><doc><str>test_id_1</str></doc><doc><str>test_id_2</str></doc></result>')
+    
+    @internet_archive.stub :get_api_results, mock_api_results do
+      @internet_archive.check(@task)
+      
+      # Verify that the task status is updated to succeeded
+      @task.reload
+      assert_equal Task::Status::SUCCEEDED, @task.status
+
+      # Verify that the database is updated with the items found
+      assert_equal 2, Book.where(exists_in_internet_archive: 'true').count
+
+      books = Book.where(exists_in_internet_archive: 'true')
+      books.each { |book| puts book.inspect }
+
+      assert Book.exists?(ia_identifier: 'test_id_1')
+      assert Book.exists?(ia_identifier: 'test_id_2')
+      # assert Book.exists?(ia_identifier: 'test_id_1')
+      # assert Book.exists?(ia_identifier: 'test_id_2')
+    end
+  end
+
+  test 'check should raise error if another check is in progress' do 
+    Task.create!(name: 'Running Task', service: Service::INTERNET_ARCHIVE, status: Task::Status::RUNNING)
+    assert_raises(RuntimeError, 'Another Internet Archive check is in progress.') do 
+      @internet_archive.check 
+    end
+  end
+
+
+  test 'check should update the task status to succeeded in completion' do
+    mock_api_results = Nokogiri::XML('<result numFound="1"><doc><str>test_id</str></doc></result>')
+    @internet_archive.stub :get_api_results, mock_api_results do 
+      @internet_archive.stub :set_existing, nil do 
+        @internet_archive.check(@task)
+        @task.reload 
+        assert_equal Task::Status::SUCCEEDED, @task.status
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR addresses issue [55](https://github.com/orgs/medusa-project/projects/6/views/1?pane=issue&itemId=85573413&issue=medusa-project%7Cbook-tracker%7C55):

BookTracker is not accurately reflecting the book counts for Google Books or Internet Archive, despite the items in the Tasks showing accurate found items.

## Summary of Changes:

- tests were written for both `Internet Archive` and `Google `classes verifying `check` method work as expected for updating the task status
- tests were written to verify `check` method is updating the database with the items found during the check `(this part of the test was the only part FAILING)`
- pinpointed issue to `Book.bulk_update()` class method
   - the original SQL query didn't properly quote the `new_value` argument; instead it was directly inserted into the SQL string without a placeholder `$%d`
   - the `binds array` didn't match the placeholders in the SQL query; the binds array combines the `batch of identifiers and the new value to be set`; originally it `only included` the batch of identifiers, but not the `new_value`, which meant the `new_value` param was `never being properly bound to the SQL query.` 
   - with these changes the actual database should now properly update with the items found during the checks.
   - `Hathitrust` class doesn't utilize the `Book.bulk_update()` method and instead updates the book objects directly inside the check method, so that is likely why there weren't issues with it.
 - to get mocking to work for how the `Google class interacts with S3`, I used `MiniTest::Mocha` which is included in the Gemfile, along with `pry` for more interactive debugging.
- `ci.yml` was also updated to remove the `docker compose` hyphen as that's now deprecated in Github Actions


## Book.bulk_update() Old version:
```ruby
def self.bulk_update(batch, column, new_value, where_column)
    length = batch.length 
    return unless length > 0

    sql = StringIO.new
    sql << sprintf('UPDATE books SET %s = %s WHERE %s IN (',
                   column, new_value, where_column)
    length.times do |index|
          sql << "$#{index + 1}"
          if index < length - 1
             sql << ', '
          end
           sql << ');'
           binds = batch
    end
```

## New version:
```ruby
def self.bulk_update(batch, column, new_value, where_column)
    length = batch.length
    return unless length > 0

    sql = StringIO.new
    sql << sprintf('UPDATE books SET %s = $%d WHERE %s IN (',
                   column, length + 1, where_column)
    length.times do |index|
      sql << "$#{index + 1}"
      sql << ', ' if index < length - 1
    end
    sql << ');'

    binds = batch + [new_value]
  end
```
- additionally, to handle `ERROR: VACUUM cannot run inside a transaction block` error in the tests, I added a conditional before the `Book.analyze_table()` method: 

```ruby
  def self.analyze_table
    unless Rails.env.test?
      ActiveRecord::Base.connection.execute('VACUUM ANALYZE books;')
    end
  end
```



