### PR TITLE
Book count fix - updated

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -51,20 +51,17 @@ class Book < ApplicationRecord
     return unless length > 0
 
     sql = StringIO.new
-    sql << sprintf('UPDATE books SET %s = $%d WHERE %s IN (',
-                   column, length + 1, where_column)
+    sql << sprintf('UPDATE books SET %s = %s WHERE %s IN (', column, new_value, where_column)
     length.times do |index|
       sql << "$#{index + 1}"
-      sql << ', ' if index < length - 1
+      if index < length - 1
+        sql << ', '
+      end
     end
-    #   if index < length - 1
-    #     sql << ', '
-    #   end
-    # end
     sql << ');'
 
-    binds = batch + [new_value]
-
+    binds = batch 
+  
     Rails.logger.debug("Book.bulk_update(): updating #{batch.length} records")
     ActiveRecord::Base.connection.exec_query(sql.string, 'SQL', binds, prepare: true)
   rescue => e

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -51,22 +51,33 @@ class Book < ApplicationRecord
     return unless length > 0
 
     sql = StringIO.new
-    sql << sprintf('UPDATE books SET %s = %s WHERE %s IN (', column, new_value, where_column)
+    sql << sprintf('UPDATE books SET %s = $%d WHERE %s IN (', column, length + 1, where_column)
     length.times do |index|
       sql << "$#{index + 1}"
-      if index < length - 1
-        sql << ', '
-      end
+      sql << ', ' if index < length - 1
+      # if index < length - 1
+      #   sql << ', '
+      # end
     end
     sql << ');'
 
-    binds = batch 
-  
+    # new_value = ActiveRecord::Base.connection.quote(new_value == 'true')
+    new_value = new_value == 'true' ? true : false 
+    binds = batch.map { |id| [nil, id] } + [[nil, new_value]]
+    binds = batch + [new_value]
+    # binds = batch + [new_value]
+    # binds = batch 
+
+    result = ActiveRecord::Base.connection.exec_update(sql.string, 'SQL', binds)
+    # require 'pry'; binding.pry 
+    Rails.logger.debug("Book.bulk_update(): SQL query - #{sql.string}")
+    Rails.logger.debug("Book.bulk_update(): Bind values - #{binds.inspect}")
     Rails.logger.debug("Book.bulk_update(): updating #{batch.length} records")
-    ActiveRecord::Base.connection.exec_query(sql.string, 'SQL', binds, prepare: true)
+    Rails.logger.debug("Book.bulk_update(): updated #{result} records")
+
   rescue => e
-    Rails.logger.error("Book.bulk_update(): #{e}\nSQL: #{sql.string}")
-    raise e
+      Rails.logger.error("Book.bulk_update(): #{e}\nSQL: #{sql.string}")
+      raise e
   end
 
   ##

--- a/test/models/hathitrust_test.rb
+++ b/test/models/hathitrust_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+require 'mocha/minitest'
+
+class HathitrustTest < ActiveSupport::TestCase
+  def setup
+    @hathitrust = Hathitrust.new
+    @task = Task.create!(name: 'Test Task', service: Service::HATHITRUST, status: Task::Status::SUBMITTED)
+  end
+
+  test 'check_authorized? returns true when no running tasks' do 
+    assert Hathitrust.check_authorized? 
+  end
+
+  test 'check_authorized? returns false when there are running tasks' do 
+    Task.create!(name: 'Test Task', service: Service::HATHITRUST, status: Task::Status::RUNNING)
+    assert !Hathitrust.check_authorized?
+  end
+
+  test 'check updates book records correctly' do 
+    book = Book.create!(obj_id: 'test_obj_id', exists_in_hathitrust: false, hathitrust_access: 'old_access', hathitrust_rights: 'old_rights')
+
+    Hathitrust.any_instance.stubs(:find_hathifile_url).returns('http://example.com/hathifile')
+    Hathitrust.any_instance.stubs(:download_hathifile).returns('test/fixtures/files/fake_hathifile.txt')
+    File.stubs(:foreach).returns(["test_obj_id\tnew_access\tnew_rights\t\t\tUIU"])
+    File.stubs(:open).returns(["test_obj_id\tnew_access\tnew_rights\t\t\tUIU"])
+
+
+      @hathitrust.check(@task)
+
+      book.reload 
+
+      assert book.exists_in_hathitrust
+      assert_equal 'new_access', book.hathitrust_access 
+      assert_equal 'new_rights', book.hathitrust_rights
+  end
+end

--- a/test/models/internet_archive_test.rb
+++ b/test/models/internet_archive_test.rb
@@ -9,6 +9,8 @@ class InternetArchiveTest < ActiveSupport::TestCase
 
     Book.create!(bib_id: 1, ia_identifier: 'test_id_1', exists_in_internet_archive: false)
     Book.create!(bib_id: 2, ia_identifier: 'test_id_2', exists_in_internet_archive: false)
+    Book.create!(bib_id: 3, ia_identifier: 'test_id_3', exists_in_internet_archive: true)
+    Book.create!(bib_id: 4, ia_identifier: 'test_id_4', exists_in_internet_archive: true)
   end
 
   def teardown 
@@ -26,16 +28,52 @@ class InternetArchiveTest < ActiveSupport::TestCase
       @task.reload
       assert_equal Task::Status::SUCCEEDED, @task.status
 
+      books = Book.where(exists_in_internet_archive: true)
+      books.each do |book|
+        assert book.exists_in_internet_archive
+      end
+
       # Verify that the database is updated with the items found
-      assert_equal 2, Book.where(exists_in_internet_archive: 'true').count
+      assert_equal 4, Book.where(exists_in_internet_archive: true).count
+    end
+  end
 
-      books = Book.where(exists_in_internet_archive: 'true')
-      books.each { |book| puts book.inspect }
+  # verify database changes
+  test 'set_existing updates the book objects correctly' do 
 
-      assert Book.exists?(ia_identifier: 'test_id_1')
-      assert Book.exists?(ia_identifier: 'test_id_2')
-      # assert Book.exists?(ia_identifier: 'test_id_1')
-      # assert Book.exists?(ia_identifier: 'test_id_2')
+    Book.delete_all 
+
+    batch = ["test_id_1", "test_id_2"]
+    bk1 = Book.create!(bib_id: 1, ia_identifier: 'test_id_1', exists_in_internet_archive: false)
+    bk2 = Book.create!(bib_id: 2, ia_identifier: 'test_id_2', exists_in_internet_archive: false)
+
+    assert_equal 0, Book.where(exists_in_internet_archive: true).count
+
+    @internet_archive.send(:set_existing, batch)
+
+    bk1.reload 
+    bk2.reload 
+
+    assert_equal 2, Book.where(exists_in_internet_archive: true).count
+
+    assert_equal true, bk1.exists_in_internet_archive
+    assert_equal true, bk2.exists_in_internet_archive
+    assert Book.exists?(ia_identifier: 'test_id_1', exists_in_internet_archive: true)
+    assert Book.exists?(ia_identifier: 'test_id_2', exists_in_internet_archive: true)
+  end
+
+  test 'set_existing calls bulk_update with correct arguments' do 
+    Book.delete_all 
+
+    batch = ["test_id_1", "test_id_2"]
+
+    Book.stub(:bulk_update, ->(batch_arg, column, new_value, where_column) {
+      assert_equal ['test_id_1', 'test_id_2'], batch_arg 
+      assert_equal 'exists_in_internet_archive', column 
+      assert_equal 'true', new_value 
+      assert_equal 'ia_identifier', where_column 
+    }) do 
+      @internet_archive.send(:set_existing, batch)
     end
   end
 
@@ -50,7 +88,7 @@ class InternetArchiveTest < ActiveSupport::TestCase
   test 'check should update the task status to succeeded in completion' do
     mock_api_results = Nokogiri::XML('<result numFound="1"><doc><str>test_id</str></doc></result>')
     @internet_archive.stub :get_api_results, mock_api_results do 
-      @internet_archive.stub :set_existing, nil do 
+      @internet_archive.stub :set_existing, ->(batch) { Rails.logger.debug("Batch set: #{batch.inspect}") } do 
         @internet_archive.check(@task)
         @task.reload 
         assert_equal Task::Status::SUCCEEDED, @task.status


### PR DESCRIPTION
This addresses issue [55](https://github.com/orgs/medusa-project/projects/6?pane=issue&itemId=85573413&issue=medusa-project%7Cbook-tracker%7C55) The previous PR did not seem to resolve the issue with the number of book objects found during a service check for Internet Archive & Google vs the objects actually updated in the database.

Summary of Changes:

- The`Book.bulk_update()` method was changed
- More debugging statements added for ease of troubleshooting (can remove if too cluttered)
- Tests for `Hathitrust` 

## Overview of Book.bulk_update:

- the sql construction sets a placeholder for `new_value` to be correctly positioned in the list of bind params 
   - after listing the placeholders, the next placeholder `(length + 1)` is used for the `new_value`, ensuring that it's correctly positioned as the last bind parameter
    - `column`-> column to be updated (ie `'exists_in_internet_archive`')
    - `length + 1 `-> placeholder for `new_value` correctly positioned
    - `where_column `-> used in the WHERE clause (ie `ia_identifier`)
- ensure the `new_value` is a boolean value
- change `exec_query` to `exec_update` to handle the bind params differently - the latter executes an update SQL statement and returns the number of rows affected.
- format the bind params as `[nil, value]`

### Debugging output before this change - 

Number of records updating - `#{batch.length}`records (2)
Number of records updated - execution of the SQL query's row count (0)

```ruby
Book.bulk_update(): SQL query - UPDATE books SET exists_in_internet_archive = $3 WHERE ia_identifier IN ($1, $2);
Book.bulk_update(): Bind values - ["test_id_1", "test_id_2", true]
Book.bulk_update(): updating 2 records
Book.bulk_update(): Executing query
SQL (0.4ms)  UPDATE books SET exists_in_internet_archive = $3 WHERE ia_identifier IN ($1, $2);  [[nil, "test_id_1"], [nil, "test_id_2"], [nil, true]]
Book.bulk_update(): Number of records updated - 0
```

### Debugging output after this change - 

Number of records updating - `#{batch.length}` records (2)
Number of records updated - execution of the SQL query's row count (2)


```ruby
Book Count (0.4ms)  SELECT COUNT(*) FROM "books" WHERE "books"."exists_in_internet_archive" = $1  [["exists_in_internet_archive", true]]
SQL (0.5ms)  UPDATE books SET exists_in_internet_archive = $3 WHERE ia_identifier IN ($1, $2);  [[nil, "test_id_1"], [nil, "test_id_2"], [nil, true]]
Book.bulk_update(): SQL query - UPDATE books SET exists_in_internet_archive = $3 WHERE ia_identifier IN ($1, $2);
Book.bulk_update(): Bind values - ["test_id_1", "test_id_2", true]
Book.bulk_update(): updating 2 records
Book.bulk_update(): Number of records updated - 2
```