### PR TITLE
DB update - Book and Internet Archive class

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -51,30 +51,19 @@ class Book < ApplicationRecord
     return unless length > 0
 
     sql = StringIO.new
-    sql << sprintf('UPDATE books SET %s = $%d WHERE %s IN (', column, length + 1, where_column)
+    sql << sprintf('UPDATE books SET %s = %s WHERE %s IN (', column, new_value, where_column)
     length.times do |index|
       sql << "$#{index + 1}"
-      sql << ', ' if index < length - 1
-      # if index < length - 1
-      #   sql << ', '
-      # end
+      if index < length - 1
+        sql << ', '
+      end
     end
     sql << ');'
 
-    # new_value = ActiveRecord::Base.connection.quote(new_value == 'true')
-    new_value = new_value == 'true' ? true : false 
-    binds = batch.map { |id| [nil, id] } + [[nil, new_value]]
-    binds = batch + [new_value]
-    # binds = batch + [new_value]
-    # binds = batch 
+    binds = batch 
 
-    result = ActiveRecord::Base.connection.exec_update(sql.string, 'SQL', binds)
-    # require 'pry'; binding.pry 
-    Rails.logger.debug("Book.bulk_update(): SQL query - #{sql.string}")
-    Rails.logger.debug("Book.bulk_update(): Bind values - #{binds.inspect}")
     Rails.logger.debug("Book.bulk_update(): updating #{batch.length} records")
-    Rails.logger.debug("Book.bulk_update(): updated #{result} records")
-
+    ActiveRecord::Base.connection.exec_query(sql.string, 'SQL', binds, prepare: true)
   rescue => e
       Rails.logger.error("Book.bulk_update(): #{e}\nSQL: #{sql.string}")
       raise e

--- a/app/models/internet_archive.rb
+++ b/app/models/internet_archive.rb
@@ -52,10 +52,12 @@ class InternetArchive
         ia_id = node.content
         ia_id_batch << ia_id 
 
-        book = Book.find_by_obj_id(ia_id)
+        Rails.logger.debug("Looking for book with ia_identifier: #{ia_id}")
+        book = Book.find_by(ia_identifier: ia_id)
         if book 
           book.update!(exists_in_internet_archive: true)
         end
+        Rails.logger.debug("Found book: #{book.inspect}")
         # ia_id_batch << node.content
         # set_existing_if_necessary(ia_id_batch)
 

--- a/app/models/internet_archive.rb
+++ b/app/models/internet_archive.rb
@@ -49,8 +49,15 @@ class InternetArchive
 
       doc.xpath('//result/doc/str').each_with_index do |node, index|
         actual_num_items += 1
-        ia_id_batch << node.content
-        set_existing_if_necessary(ia_id_batch)
+        ia_id = node.content
+        ia_id_batch << ia_id 
+
+        book = Book.find_by_obj_id(ia_id)
+        if book 
+          book.update!(exists_in_internet_archive: true)
+        end
+        # ia_id_batch << node.content
+        # set_existing_if_necessary(ia_id_batch)
 
         if index % TASK_UPDATE_INTERVAL == 0
           task.update!(name: "Checking Internet Archive: scanned "\
@@ -74,7 +81,8 @@ class InternetArchive
                    status: Task::Status::SUCCEEDED)
       puts task.name
     ensure
-      set_existing(ia_id_batch)
+      Book.where(ia_identifier: ia_id_batch).update_all(exists_in_internet_archive: true)
+      # set_existing(ia_id_batch)
     end
   end
   ##


### PR DESCRIPTION
- Changed the sql construction inside `Book.bulk_update()` back to its original form `(removing '$%d', 'length + 1', etc)`. 
- Updated Internet Archive check method to follow Hathitrust - `directly updating each book object inside the method and skipping the call to the Book bulk_update all together`
  - if this works then it can `verify the issue with the DB not updating was with the sql construction`
- Keeps new tests in place - everything still passes