### PR TITLE
Fix: HathiTrust Check Failing 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,8 @@ gem 'rails', '~> 7'
 gem 'sassc'
 gem 'scars-bootstrap-theme', github: 'medusa-project/scars-bootstrap-theme',
     branch: 'release/bootstrap-4.4'
+gem 'selenium-webdriver'
+gem 'webdrivers'
 gem 'sprockets-rails'
 gem 'uglifier', '>= 1.3.0'
 gem 'uiuc_lib_ad', git: 'https://github.com/UIUCLibrary/uiuc_lib_ad.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -300,8 +300,13 @@ GEM
       nokogiri (>= 1.13.10)
       rexml
     ruby2_keywords (0.0.5)
+    rubyzip (2.4.1)
     sassc (2.4.0)
       ffi (~> 1.9)
+    selenium-webdriver (4.10.0)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -333,7 +338,12 @@ GEM
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (2.5.0)
+    webdrivers (5.3.1)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (~> 4.0, < 4.11)
     webrick (1.8.1)
+    websocket (1.2.11)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -369,9 +379,11 @@ DEPENDENCIES
   rails (~> 7)
   sassc
   scars-bootstrap-theme!
+  selenium-webdriver
   sprockets-rails
   uglifier (>= 1.3.0)
   uiuc_lib_ad!
+  webdrivers
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -241,6 +241,7 @@ class BooksController < ApplicationController
     respond_to do |format|
       format.html
       format.json { render json: @book }
+      format.any { head :not_acceptable}
     end
   end
 

--- a/app/models/hathitrust.rb
+++ b/app/models/hathitrust.rb
@@ -101,31 +101,61 @@ class Hathitrust
   private
   
   def find_hathifile_url(task)
+    require 'selenium-webdriver'
     # As there is no single URI for the latest HathiFile, we have to scrape
     # the HathiFile listing out of the index HTML page.
     task.update!(name: 'Checking HathiTrust: downloading HathiFile index...')
     puts task.name
 
-    uri          = URI.parse('https://www.hathitrust.org/hathifiles')
-    response     = Net::HTTP.get_response(uri)
-    location     = response['location']
-    base_url     = 'https://www.hathitrust.org'
-    res          = base_url + location
+    options = Selenium::WebDriver::Chrome::Options.new
+    options.add_argument('--headless=new') # Run in headless mode
+    options.add_argument('--disable-gpu') # Disable GPU hardware acceleration
+    options.add_argument('--no-sandbox') # Bypass OS security
+    options.add_argument('--disable-blink-features=AutomationControlled') # Disable automation control
+    options.add_argument('--window-size=1920,1080') # Set window size for headless mode
+    options.add_argument("user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36")
 
-    if response.code.start_with?("3")
-      new_response = Net::HTTP.get_response(URI(res))
-      page         = Nokogiri::HTML(new_response.body)
-    else
-      page         = Nokogiri::HTML(response.body)
+    options.add_option('excludeSwitches', ['enable-automation']) # Exclude automation switch
+    options.add_option('useAutomationExtension', false) # Disable automation extension
+
+    driver = Selenium::WebDriver.for(:chrome, options: options)
+    begin
+      driver.navigate.to('https://www.hathitrust.org/hathifiles')
+      
+      wait = Selenium::WebDriver::Wait.new(timeout: 15)
+      wait.until do 
+        driver.find_elements(css: '.btable-wrapper table.btable tbody tr td a').any? 
+      end
+
+      links = driver.find_elements(css: '.btable-wrapper table.btable tbody tr td a')
+      hathi_links = links.select { |a| a.text.start_with?('hathi_full_') }
+      latest = hathi_links.sort_by { |a| a.text }.last
+      latest['href']
+    ensure
+      driver.quit
     end
-
-    # Scrape the URI of the latest HathiFile out of the index
-    node     = page.css('.btable-wrapper table.btable tbody tr td a')
-                   .select{ |h| h.text.start_with?('hathi_full_') }
-                   .sort{ |x,y| x.text <=> y.text }
-                   .reverse[0]
-    node['href']
   end
+
+    # uri          = URI.parse('https://www.hathitrust.org/hathifiles')
+    # response     = Net::HTTP.get_response(uri)
+    # location     = response['location']
+    # base_url     = 'https://www.hathitrust.org'
+    # res          = base_url + location
+
+    # if response.code.start_with?("3")
+    #   new_response = Net::HTTP.get_response(URI(res))
+    #   page         = Nokogiri::HTML(new_response.body)
+    # else
+    #   page         = Nokogiri::HTML(response.body)
+    # end
+
+    # # Scrape the URI of the latest HathiFile out of the index
+    # node     = page.css('.btable-wrapper table.btable tbody tr td a')
+    #                .select{ |h| h.text.start_with?('hathi_full_') }
+    #                .sort{ |x,y| x.text <=> y.text }
+    #                .reverse[0]
+    # node['href']
+  # end
 
   ##
   # @param uri [String] The URI/URL at which the HathiFile resides.

--- a/app/models/hathitrust.rb
+++ b/app/models/hathitrust.rb
@@ -121,7 +121,7 @@ class Hathitrust
     driver = Selenium::WebDriver.for(:chrome, options: options)
     begin
       driver.navigate.to('https://www.hathitrust.org/hathifiles')
-      
+
       wait = Selenium::WebDriver::Wait.new(timeout: 15)
       wait.until do 
         driver.find_elements(css: '.btable-wrapper table.btable tbody tr td a').any? 
@@ -136,26 +136,6 @@ class Hathitrust
     end
   end
 
-    # uri          = URI.parse('https://www.hathitrust.org/hathifiles')
-    # response     = Net::HTTP.get_response(uri)
-    # location     = response['location']
-    # base_url     = 'https://www.hathitrust.org'
-    # res          = base_url + location
-
-    # if response.code.start_with?("3")
-    #   new_response = Net::HTTP.get_response(URI(res))
-    #   page         = Nokogiri::HTML(new_response.body)
-    # else
-    #   page         = Nokogiri::HTML(response.body)
-    # end
-
-    # # Scrape the URI of the latest HathiFile out of the index
-    # node     = page.css('.btable-wrapper table.btable tbody tr td a')
-    #                .select{ |h| h.text.start_with?('hathi_full_') }
-    #                .sort{ |x,y| x.text <=> y.text }
-    #                .reverse[0]
-    # node['href']
-  # end
 
   ##
   # @param uri [String] The URI/URL at which the HathiFile resides.

--- a/test/models/hathitrust_test.rb
+++ b/test/models/hathitrust_test.rb
@@ -33,4 +33,20 @@ class HathitrustTest < ActiveSupport::TestCase
       assert_equal 'new_access', book.hathitrust_access 
       assert_equal 'new_rights', book.hathitrust_rights
   end
+
+  test 'selenium webdriver correctly scrapes the HathiTrust page' do 
+    # Mock the Selenium WebDriver
+    driver = mock('driver')
+    navigation = mock('navigation')
+    Selenium::WebDriver.stubs(:for).returns(driver)
+    driver.stubs(:navigate).returns(navigation)
+    navigation.stubs(:to).with('https://www.hathitrust.org/hathifiles')
+    driver.stubs(:find_elements).returns([
+      stub(text: 'hathi_full_20250501.txt', '[]' => 'https://www.hathitrust.org/hathifiles/'),
+    ])
+    driver.stubs(:quit)
+
+    url = @hathitrust.send(:find_hathifile_url, @task)
+    assert_equal 'https://www.hathitrust.org/hathifiles/', url
+  end
 end


### PR DESCRIPTION
Issue [59](https://github.com/orgs/medusa-project/projects/6?pane=issue&itemId=109515625&issue=medusa-project%7Cbook-tracker%7C59) - Hathitrust website has implemented Cloudflare security to block webscraper tools/bots, resulting in our `Nokogiri + Net::HTTP` scraping code being blocked with a `403 Forbidden Error` when accessing the latest hathifile uri. This fix instead uses `Selenium` to bypass the blocks and mimic a real user/browser.

### Summary of Changes:
- install `webdrivers` and `selenium` gems
- inside `Hathitrust Model > (private method) find_hathifile_url(task):`
  - require `selenium-webdriver` gem
  - replace Nokogiri + Net::HTTP code with `Selenium::WebDriver` to do the following:
    - run in headless browser to be less detectable
    - disable Chrome's automation extension
    - hides navigator.webdriver property that is usually set when browser is controlled by automation
    - when browser navigates to `hathifiles uri` it adds a `time delay` to give the hathifiles table time to load
    - browser finds the correct css selector for the files and selects links of those that start with `'hathi_full_'`
    - those links are `sorted by most recent` to pull the latest hathifile to be read by the `download_hathifile()` method

### Tested Locally:
- running the rake task (`bin/rails books:check_hathitrust`) now results in a successful check:

<img width="1170" alt="Screenshot 2025-05-14 at 11 20 54 AM" src="https://github.com/user-attachments/assets/51473405-84b4-4eb9-a2ee-841c3fec6a69" />
