### PR TITLE
BugFix: PG::NumericValueOutOfRange

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -53,7 +53,7 @@ class BooksController < ApplicationController
         # Compile a list of entered IDs for which books were not found.
         if bib_ids.any?
           sql = "SELECT * FROM "\
-          "(values #{bib_ids.map{ |id| "(#{id})" }.join(',')}) as T(ID) "\
+          "(values #{bib_ids.map{ |id|"('#{id.gsub("'", "''")}')" }.join(',')}) as T(ID) "\
           "EXCEPT "\
           "SELECT bib_id "\
           "FROM books;"

--- a/db/migrate/20250602185801_change_bib_id_to_string_in_books.rb
+++ b/db/migrate/20250602185801_change_bib_id_to_string_in_books.rb
@@ -1,0 +1,5 @@
+class ChangeBibIdToStringInBooks < ActiveRecord::Migration[7.1]
+  def change
+    change_column :books, :bib_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2022_09_16_162423) do
+ActiveRecord::Schema[7.1].define(version: 2025_06_02_185801) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "books", force: :cascade do |t|
-    t.integer "bib_id"
+    t.string "bib_id"
     t.string "oclc_number"
     t.string "obj_id"
     t.string "title"

--- a/test/fixtures/books.yml
+++ b/test/fixtures/books.yml
@@ -1,7 +1,7 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  bib_id: 1
+  bib_id: "1"
   oclc_number: MyString
   obj_id: 001
   title: MyString
@@ -17,7 +17,7 @@ one:
   hathitrust_rights: MyString
 
 two:
-  bib_id: 2
+  bib_id: "2"
   oclc_number: MyString
   obj_id: 002
   title: MyString
@@ -33,7 +33,7 @@ two:
   hathitrust_rights: MyString
 
 three:
-  bib_id: 3
+  bib_id: "3"
   oclc_number: MyString
   obj_id: 003
   title: MyString
@@ -49,7 +49,7 @@ three:
   hathitrust_rights: MyString
 
 four:
-  bib_id: 4
+  bib_id: "4"
   oclc_number: MyString
   obj_id: 004
   title: MyString
@@ -66,7 +66,7 @@ four:
 
 five: 
   id: 1
-  bib_id: 272087
+  bib_id: "272087"
   oclc_number: "03493895"
   obj_id: "30112048976390"
   title: "National Clearinghouse on Aging thesaurus"
@@ -86,7 +86,7 @@ five:
 
 six: 
   id: 868521
-  bib_id: 4737365
+  bib_id: "4737365"
   oclc_number: "55069825"
   obj_id: "ark:/13960/t4pk0b42v"
   title: "Crito een dialoog van Plato /"

--- a/test/models/book_test.rb
+++ b/test/models/book_test.rb
@@ -24,7 +24,7 @@ class BookTest < ActiveSupport::TestCase
     books = [
       Book.new(
             author: 'Dr. Seuss',
-            bib_id: 123,
+            bib_id: '123',
             date: '1974',
             exists_in_hathitrust: false,
             exists_in_internet_archive: false,
@@ -42,7 +42,7 @@ class BookTest < ActiveSupport::TestCase
             volume: nil),
       Book.new(
             author: 'Dr. Seuss',
-            bib_id: 234,
+            bib_id: '234',
             date: '1975',
             exists_in_hathitrust: false,
             exists_in_internet_archive: false,
@@ -60,7 +60,7 @@ class BookTest < ActiveSupport::TestCase
             volume: nil),
       Book.new( # same obj_id as the first one
             author: 'Dr. Seuss',
-            bib_id: 123,
+            bib_id: '123',
             date: '1975',
             exists_in_hathitrust: false,
             exists_in_internet_archive: false,
@@ -108,7 +108,7 @@ class BookTest < ActiveSupport::TestCase
 
     book = Book.from_marcxml_record(key: key, record: record)
     assert_equal key, book.source_path
-    assert_equal 272087, book.bib_id
+    assert_equal '272087', book.bib_id
     assert_equal "03493895", book.oclc_number
     assert_equal "", book.author
     assert_equal "National Clearinghouse on Aging thesaurus", book.title
@@ -125,7 +125,7 @@ class BookTest < ActiveSupport::TestCase
 
     data = 
       
-        {id: b2.id, bib_id: 2, oclc_number: "MyString", 
+        {id: b2.id, bib_id: "2", oclc_number: "MyString", 
         obj_id: "2", title: "MyString", volume: "MyString", 
         author: "MyString", language: nil, subjects: nil, 
         date: "MyString", url: nil, catalog_url: b2.uiuc_catalog_url, hathitrust_url: nil, 
@@ -141,7 +141,7 @@ class BookTest < ActiveSupport::TestCase
 
     data = 
   
-      {id: b2.id, bib_id: 2, oclc_number: "MyString", 
+      {id: b2.id, bib_id: "2", oclc_number: "MyString", 
       obj_id: "2", title: "MyString", volume: "MyString", 
       author: "MyString", language: nil, subjects: nil, 
       date: "MyString", url: nil, catalog_url: b2.uiuc_catalog_url, hathitrust_url: nil, 


### PR DESCRIPTION
Possible resolution to Issue [55](https://github.com/orgs/medusa-project/projects/6/views/1?pane=issue&itemId=85573413&issue=medusa-project%7Cbook-tracker%7C55)

> The Book Tracker has not been reflecting accurate numbers for Google Books for a few years...
The Google XML files appear to be getting ingested correctly into Medusa...
So we know that Medusa is holding all of our latest Google XML data ingested from local storage, and indexing the lates Google Grin data. The problem is that the Book Tracker application does not appear to be correctly cross-referencing newly added items...

Cloudwatch error log (/ecs/book-tracker)

```ruby
Importing MARCXML records: scanned 149900 records in 55289 files (no progress available)
E, [2025-05-06T15:13:53.958659 #1] ERROR -- : Book.bulk_upsert(): PG::NumericValueOutOfRange: ERROR:  value "99209636312205899" is out of range for type integer
```

### Summary of Changes:
- Migration to change `bib_id` type from integer to string 
- Many objects have likely been silently failing during the `Book.bulk_upsert()` process, likely leading to large number of missing items that are present in the `S3 MARCxml` files but not within book tracker.
- Update fixture data for `bib_id` as string
- Update tests to look for `bib_id` as string
- Update SQL constructor for bib_id inside `BooksController` so it treats the value as a string not integer: `(values (11111), (2222)) as T(ID)` to `(values ('11111'),('2222')) as T(ID)`