### PR TITLE
Install aws-login within Dockerfile

### DIFF
--- a/docker/book-tracker-aws/Dockerfile
+++ b/docker/book-tracker-aws/Dockerfile
@@ -17,7 +17,15 @@ ENV RAILS_SERVE_STATIC_FILES=true
 RUN apt-get update && apt-get install -y \
   build-essential \
   git \
-  libpq-dev
+  libpq-dev \
+  curl
+
+# Install Node.js and npm 
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
+    apt-get install -y nodejs
+
+# Install aws-login globally 
+RUN npm install -g aws-login
 
 # Set Working Directory
 RUN mkdir app


### PR DESCRIPTION
Import process keeps failing with the following error:

`Import failed: unable to sign request without credentials set`

- Aws credentials are most likely expiring during the long import process
- Install aws-login inside the Dockerfile so the AWS SDK can invoke the command as needed 